### PR TITLE
Replace govuk-lint with rubocop-govuk and fix offenses

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,2 +1,6 @@
+inherit_gem:
+  rubocop-govuk:
+    - config/default.yml
+
 AllCops:
   TargetRubyVersion: 2.6

--- a/Gemfile
+++ b/Gemfile
@@ -1,14 +1,14 @@
-source 'https://rubygems.org'
+source "https://rubygems.org"
 
-ruby File.read('.ruby-version').strip
+ruby File.read(".ruby-version").strip
 
-gem 'puma'
-gem 'rack'
-gem 'sinatra'
-gem 'sinatra-contrib'
-gem 'zendesk_api'
+gem "puma"
+gem "rack"
+gem "sinatra"
+gem "sinatra-contrib"
+gem "zendesk_api"
 
 group :test, :development do
-  gem 'pry-byebug'
+  gem "pry-byebug"
   gem "rubocop-govuk"
 end

--- a/Gemfile
+++ b/Gemfile
@@ -9,6 +9,6 @@ gem 'sinatra-contrib'
 gem 'zendesk_api'
 
 group :test, :development do
-  gem 'govuk-lint'
   gem 'pry-byebug'
+  gem "rubocop-govuk"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,14 +7,9 @@ GEM
     coderay (1.1.2)
     faraday (0.15.4)
       multipart-post (>= 1.2, < 3)
-    ffi (1.10.0)
-    govuk-lint (3.11.2)
-      rubocop (~> 0.64)
-      rubocop-rspec (~> 1.28)
-      scss_lint
     hashie (3.6.0)
     inflection (1.0.0)
-    jaro_winkler (1.5.2)
+    jaro_winkler (1.5.4)
     method_source (0.9.2)
     mime-types (3.2.2)
       mime-types-data (~> 3.2015)
@@ -22,8 +17,8 @@ GEM
     multi_json (1.13.1)
     multipart-post (2.1.0)
     mustermann (1.0.3)
-    parallel (1.17.0)
-    parser (2.6.3.0)
+    parallel (1.18.0)
+    parser (2.6.5.0)
       ast (~> 2.4.0)
     pry (0.12.2)
       coderay (~> 1.1.0)
@@ -36,28 +31,23 @@ GEM
     rack-protection (2.0.5)
       rack
     rainbow (3.0.0)
-    rake (12.3.2)
-    rb-fsevent (0.10.3)
-    rb-inotify (0.10.0)
-      ffi (~> 1.0)
-    rubocop (0.68.1)
+    rubocop (0.76.0)
       jaro_winkler (~> 1.5.1)
       parallel (~> 1.10)
-      parser (>= 2.5, != 2.5.1.1)
+      parser (>= 2.6)
       rainbow (>= 2.2.2, < 4.0)
       ruby-progressbar (~> 1.7)
-      unicode-display_width (>= 1.4.0, < 1.6)
-    rubocop-rspec (1.32.0)
-      rubocop (>= 0.60.0)
-    ruby-progressbar (1.10.0)
-    sass (3.7.4)
-      sass-listen (~> 4.0.0)
-    sass-listen (4.0.0)
-      rb-fsevent (~> 0.9, >= 0.9.4)
-      rb-inotify (~> 0.9, >= 0.9.7)
-    scss_lint (0.58.0)
-      rake (>= 0.9, < 13)
-      sass (~> 3.5, >= 3.5.5)
+      unicode-display_width (>= 1.4.0, < 1.7)
+    rubocop-govuk (1.0.0)
+      rubocop (~> 0.76)
+      rubocop-rails (~> 2)
+      rubocop-rspec (~> 1.28)
+    rubocop-rails (2.3.2)
+      rack (>= 1.1)
+      rubocop (>= 0.72.0)
+    rubocop-rspec (1.36.0)
+      rubocop (>= 0.68.1)
+    ruby-progressbar (1.10.1)
     sinatra (2.0.5)
       mustermann (~> 1.0)
       rack (~> 2.0)
@@ -71,7 +61,7 @@ GEM
       sinatra (= 2.0.5)
       tilt (>= 1.3, < 3)
     tilt (2.0.9)
-    unicode-display_width (1.5.0)
+    unicode-display_width (1.6.0)
     zendesk_api (1.19.0)
       faraday (~> 0.9)
       hashie (>= 3.5.2, < 4.0.0)
@@ -83,10 +73,10 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  govuk-lint
   pry-byebug
   puma
   rack
+  rubocop-govuk
   sinatra
   sinatra-contrib
   zendesk_api

--- a/config.ru
+++ b/config.ru
@@ -1,3 +1,3 @@
-require 'bundler/setup'
-require './displayscreen'
+require "bundler/setup"
+require "./displayscreen"
 run Sinatra::Application

--- a/displayscreen.rb
+++ b/displayscreen.rb
@@ -2,7 +2,7 @@ require 'sinatra'
 require 'zendesk_api'
 
 configure do
-  set :protection, :except => :frame_options
+  set :protection, except: :frame_options
 end
 
 helpers do

--- a/displayscreen.rb
+++ b/displayscreen.rb
@@ -35,7 +35,7 @@ get '/' do
   user_protected!
   dark_mode = true unless params[:dark_mode] && params[:dark_mode] == 'false'
   hide_low_queue = true unless params[:hide_low_queue] && params[:hide_low_queue] == 'false'
-  number_of_tickets = {"high" => 0, "normal" => 0, "low" => 0}
+  number_of_tickets = { "high" => 0, "normal" => 0, "low" => 0 }
   # This would be much nicer if we could get ticket counts broken down by priority from the Zendesk API
   zendesk.view.find!(id: ENV['ZENDESK_VIEW_ID']).tickets.all! do |ticket|
     status = ticket.fetch("status", "new")

--- a/displayscreen.rb
+++ b/displayscreen.rb
@@ -1,5 +1,5 @@
-require 'sinatra'
-require 'zendesk_api'
+require "sinatra"
+require "zendesk_api"
 
 configure do
   set :protection, except: :frame_options
@@ -9,39 +9,39 @@ helpers do
   def user_protected!
     return if user_authorized?
 
-    headers['WWW-Authenticate'] = 'Basic realm="GOV.UK Zendesk Display Screen"'
+    headers["WWW-Authenticate"] = 'Basic realm="GOV.UK Zendesk Display Screen"'
     halt 401
   end
 
   def user_authorized?
     @auth ||= Rack::Auth::Basic::Request.new(request.env)
-    @auth.provided? && @auth.basic? && @auth.credentials && @auth.credentials == [ENV['AUTH_USERNAME'], ENV['AUTH_PASSWORD']]
+    @auth.provided? && @auth.basic? && @auth.credentials && @auth.credentials == [ENV["AUTH_USERNAME"], ENV["AUTH_PASSWORD"]]
   end
 
   def zendesk
     @zendesk ||= ZendeskAPI::Client.new do |config|
       config.url = "https://#{ENV['ZENDESK_SUBDOMAIN']}.zendesk.com/api/v2"
-      config.username = ENV['ZENDESK_API_USERNAME']
-      config.token = ENV['ZENDESK_API_TOKEN']
+      config.username = ENV["ZENDESK_API_USERNAME"]
+      config.token = ENV["ZENDESK_API_TOKEN"]
     end
   end
 end
 
-unless ENV['ZENDESK_SUBDOMAIN'] && ENV['ZENDESK_API_USERNAME'] && ENV['ZENDESK_API_TOKEN'] && ENV['ZENDESK_VIEW_ID'] && ENV['AUTH_USERNAME'] && ENV['AUTH_PASSWORD']
-  raise 'The ZENDESK_SUBDOMAIN, ZENDESK_API_USERNAME, ZENDESK_API_TOKEN, ZENDESK_VIEW_ID, AUTH_USERNAME and AUTH_PASSWORD environment variables must be set to run this application.'
+unless ENV["ZENDESK_SUBDOMAIN"] && ENV["ZENDESK_API_USERNAME"] && ENV["ZENDESK_API_TOKEN"] && ENV["ZENDESK_VIEW_ID"] && ENV["AUTH_USERNAME"] && ENV["AUTH_PASSWORD"]
+  raise "The ZENDESK_SUBDOMAIN, ZENDESK_API_USERNAME, ZENDESK_API_TOKEN, ZENDESK_VIEW_ID, AUTH_USERNAME and AUTH_PASSWORD environment variables must be set to run this application."
 end
 
-get '/' do
+get "/" do
   user_protected!
-  dark_mode = true unless params[:dark_mode] && params[:dark_mode] == 'false'
-  hide_low_queue = true unless params[:hide_low_queue] && params[:hide_low_queue] == 'false'
+  dark_mode = true unless params[:dark_mode] && params[:dark_mode] == "false"
+  hide_low_queue = true unless params[:hide_low_queue] && params[:hide_low_queue] == "false"
   number_of_tickets = { "high" => 0, "normal" => 0, "low" => 0 }
   # This would be much nicer if we could get ticket counts broken down by priority from the Zendesk API
-  zendesk.view.find!(id: ENV['ZENDESK_VIEW_ID']).tickets.all! do |ticket|
+  zendesk.view.find!(id: ENV["ZENDESK_VIEW_ID"]).tickets.all! do |ticket|
     status = ticket.fetch("status", "new")
     next if %w(hold pending solved closed).include?(status)
 
-    number_of_tickets[ticket['priority']] = number_of_tickets[ticket['priority']].to_i.next
+    number_of_tickets[ticket["priority"]] = number_of_tickets[ticket["priority"]].to_i.next
   end
   erb :index, locals: { number_of_tickets: number_of_tickets, dark_mode: dark_mode, hide_low_queue: hide_low_queue }
 end


### PR DESCRIPTION
- The GOV.UK Lint gem is deprecated in favour of using Rubocop directly
   with a set of shared configs.
 - See https://github.com/alphagov/govuk-rfcs/pull/ 100 for more context.

https://trello.com/c/CdBFg6yw/1521-replace-govuk-lint-with-rubocop-govuk