### PR TITLE
Bump activesupport from 7.0.3 to 7.0.3.1

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (7.0.3)
+    activesupport (7.0.3.1)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 1.6, < 2)
       minitest (>= 5.1)
@@ -13,14 +13,14 @@ GEM
     faraday (0.15.4)
       multipart-post (>= 1.2, < 3)
     hashie (3.6.0)
-    i18n (1.10.0)
+    i18n (1.11.0)
       concurrent-ruby (~> 1.0)
     inflection (1.0.0)
     method_source (0.9.2)
     mime-types (3.2.2)
       mime-types-data (~> 3.2015)
     mime-types-data (3.2019.0331)
-    minitest (5.15.0)
+    minitest (5.16.2)
     multi_json (1.15.0)
     multipart-post (2.1.0)
     mustermann (1.1.1)


### PR DESCRIPTION
Apply fix for Active Record RCE vulnerability: "Change ActiveRecord::Coders::YAMLColumn default to safe_load"