### PR TITLE
Remove allow list from Dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,14 +4,3 @@ updates:
     directory: /
     schedule:
       interval: daily
-    allow:
-      # Internal gems
-      - dependency-name: rubocop-govuk
-        dependency-type: direct
-      # Framework gems
-      - dependency-name: puma
-        dependency-type: direct
-      - dependency-name: rack
-        dependency-type: direct
-      - dependency-name: sinatra
-        dependency-type: direct


### PR DESCRIPTION
Trello card: https://trello.com/c/DuA0q9Ck/2966-remove-allow-lists-from-dependabot-configs-2